### PR TITLE
Add Spring configuration validation for BPMN delegates

### DIFF
--- a/linter-core/pom.xml
+++ b/linter-core/pom.xml
@@ -79,7 +79,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.18.0</version>
+            <version>2.18.6</version>
         </dependency>
 
         <dependency>

--- a/linter-core/src/main/java/dev/dsf/linter/output/LintingType.java
+++ b/linter-core/src/main/java/dev/dsf/linter/output/LintingType.java
@@ -239,7 +239,12 @@ public enum LintingType {
     PLUGIN_DEFINITION_PROCESS_PLUGIN_RESOURCE_NOT_LOADED("Plugin definition process plugin resource not loaded."),
     PLUGIN_DEFINITION_UNPARSABLE_BPMN_RESOURCE("Plugin definition BPMN resource could not be parsed."),
     PLUGIN_DEFINITION_UNPARSABLE_FHIR_RESOURCE("Plugin definition FHIR resource could not be parsed."),
-    PLUGIN_DEFINITION_RESOURCE_VERSION_NULL("Plugin definition getResourceVersion() returned null - version pattern invalid.");
+    PLUGIN_DEFINITION_RESOURCE_VERSION_NULL("Plugin definition getResourceVersion() returned null - version pattern invalid."),
+
+    // ==================== PLUGIN DEFINITION - SPRING CONFIGURATIONS ====================
+    PLUGIN_DEFINITION_SPRING_CONFIGURATION_MISSING(
+            "A BPMN-referenced delegate or listener class is not provided as a @Bean "
+                    + "in any @Configuration class returned by getSpringConfigurations().");
 
     private final String defaultMessage;
 

--- a/linter-core/src/main/java/dev/dsf/linter/plugin/PluginDefinitionDiscovery.java
+++ b/linter-core/src/main/java/dev/dsf/linter/plugin/PluginDefinitionDiscovery.java
@@ -57,6 +57,22 @@ public final class PluginDefinitionDiscovery {
          * @return the resource version (e.g., "1.5"), or null if the version pattern is invalid
          */
         String getResourceVersion();
+
+        /**
+         * Returns the list of Spring {@code @Configuration} classes that the plugin
+         * registers with the DSF Spring application context.
+         * <p>
+         * The Camunda engine in DSF does not instantiate BPMN delegate or listener
+         * classes directly; Spring manages them via {@code @Bean} methods defined
+         * in {@code @Configuration} classes. The classes returned from this method
+         * are the ones declared via the plugin's
+         * {@code ProcessPluginDefinition#getSpringConfigurations()} method.
+         * </p>
+         *
+         * @return the list of registered Spring configuration classes, or an empty
+         *         list if none were registered or the call failed.
+         */
+        List<Class<?>> getSpringConfigurations();
     }
 
     /**
@@ -117,6 +133,20 @@ public final class PluginDefinitionDiscovery {
                 throw new RuntimeException("getResourceVersion", e);
             }
         }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public List<Class<?>> getSpringConfigurations() {
+            try {
+                List<Class<?>> r = (List<Class<?>>)
+                        delegateClass.getMethod("getSpringConfigurations").invoke(delegate);
+                return r != null ? r : Collections.emptyList();
+            } catch (NoSuchMethodException e) {
+                return Collections.emptyList();
+            } catch (Exception e) {
+                throw new RuntimeException("getSpringConfigurations", e);
+            }
+        }
     }
 
     /**
@@ -175,6 +205,20 @@ public final class PluginDefinitionDiscovery {
                 return (String) delegateClass.getMethod("getResourceVersion").invoke(delegate);
             } catch (Exception e) {
                 throw new RuntimeException("getResourceVersion", e);
+            }
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public List<Class<?>> getSpringConfigurations() {
+            try {
+                List<Class<?>> r = (List<Class<?>>)
+                        delegateClass.getMethod("getSpringConfigurations").invoke(delegate);
+                return r != null ? r : Collections.emptyList();
+            } catch (NoSuchMethodException e) {
+                return Collections.emptyList();
+            } catch (Exception e) {
+                throw new RuntimeException("getSpringConfigurations", e);
             }
         }
     }

--- a/linter-core/src/main/java/dev/dsf/linter/service/PluginLintingOrchestrator.java
+++ b/linter-core/src/main/java/dev/dsf/linter/service/PluginLintingOrchestrator.java
@@ -32,6 +32,7 @@ public class PluginLintingOrchestrator {
     private final LeftoverResourceDetector leftoverDetector;
     private final LintingReportGenerator reportGenerator;
     private final Path reportBasePath;
+    private final Logger logger;
 
     /**
      * Context information for validating a plugin in a multi-plugin environment.
@@ -57,6 +58,7 @@ public class PluginLintingOrchestrator {
         this.leftoverDetector = leftoverDetector;
         this.reportGenerator = reportGenerator;
         this.reportBasePath = reportBasePath;
+        this.logger = logger;
     }
 
     /**
@@ -104,6 +106,19 @@ public class PluginLintingOrchestrator {
                 plugin.adapter(),
                 context.projectPath()
         );
+
+        // Step 4.6: Validate Spring configuration registration
+        // (cross-references getSpringConfigurations() with BPMN delegate/listener classes)
+        List<AbstractLintItem> springConfigItems = SpringConfigurationLinter.lint(
+                plugin.adapter(),
+                plugin.bpmnFiles(),
+                context.projectDir(),
+                logger
+        );
+        if (!springConfigItems.isEmpty()) {
+            metadataItems = new ArrayList<>(metadataItems);
+            metadataItems.addAll(springConfigItems);
+        }
 
         // Step 5: Get leftover items for this plugin
         List<AbstractLintItem> leftoverItems = leftoverDetector.getItemsForPlugin(

--- a/linter-core/src/main/java/dev/dsf/linter/service/SpringConfigurationLinter.java
+++ b/linter-core/src/main/java/dev/dsf/linter/service/SpringConfigurationLinter.java
@@ -1,0 +1,343 @@
+package dev.dsf.linter.service;
+
+import dev.dsf.linter.logger.Logger;
+import dev.dsf.linter.output.LintingType;
+import dev.dsf.linter.output.LinterSeverity;
+import dev.dsf.linter.output.item.AbstractLintItem;
+import dev.dsf.linter.output.item.PluginLintItem;
+import dev.dsf.linter.plugin.PluginDefinitionDiscovery.PluginAdapter;
+
+import org.camunda.bpm.model.bpmn.Bpmn;
+import org.camunda.bpm.model.bpmn.BpmnModelInstance;
+import org.camunda.bpm.model.bpmn.instance.BaseElement;
+import org.camunda.bpm.model.bpmn.instance.EventDefinition;
+import org.camunda.bpm.model.bpmn.instance.MessageEventDefinition;
+import org.camunda.bpm.model.bpmn.instance.SendTask;
+import org.camunda.bpm.model.bpmn.instance.ServiceTask;
+import org.camunda.bpm.model.bpmn.instance.ThrowEvent;
+import org.camunda.bpm.model.bpmn.instance.camunda.CamundaExecutionListener;
+import org.camunda.bpm.model.bpmn.instance.camunda.CamundaTaskListener;
+
+import java.io.File;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Validates that every class referenced as a Camunda delegate or listener in a
+ * BPMN file is provided as a {@code @Bean} in at least one of the
+ * {@code @Configuration} classes registered via
+ * {@code ProcessPluginDefinition#getSpringConfigurations()}.
+ *
+ * <p>Background:</p>
+ * <p>
+ * In the DSF environment the Camunda engine does not instantiate Java delegate
+ * or listener classes directly. Spring creates those instances via {@code @Bean}
+ * methods declared in {@code @Configuration} classes. For those beans to be
+ * available at runtime, every BPMN-referenced class must have a corresponding
+ * {@code @Bean} method in a configuration class that is explicitly returned by
+ * {@code ProcessPluginDefinition#getSpringConfigurations()}.
+ * A missing entry typically surfaces as a {@code BeanCreationException} or
+ * {@code ClassNotFoundException} only at deployment time.
+ * </p>
+ *
+ * <p>Emitted lint items:</p>
+ * <ul>
+ *   <li><b>ERROR</b> {@link LintingType#PLUGIN_DEFINITION_SPRING_CONFIGURATION_MISSING}
+ *       for every BPMN-referenced class that is not provided as a {@code @Bean}
+ *       in any registered {@code @Configuration} class.</li>
+ *   <li><b>SUCCESS</b> when every BPMN delegate/listener reference is covered
+ *       by a {@code @Bean} in a registered configuration, or when no BPMN
+ *       delegate/listener references exist.</li>
+ * </ul>
+ */
+public final class SpringConfigurationLinter {
+
+    private static final String CAMUNDA_NS = "http://camunda.org/schema/1.0/bpmn";
+
+    /** Fully qualified name of the Spring {@code @Bean} annotation. */
+    private static final String BEAN_ANNOTATION = "org.springframework.context.annotation.Bean";
+
+    private SpringConfigurationLinter() {
+    }
+
+    /**
+     * Runs the Spring-configuration validation.
+     *
+     * @param adapter   the plugin adapter used to invoke
+     *                  {@code getSpringConfigurations()} reflectively.
+     * @param bpmnFiles BPMN files belonging to this plugin (used to collect
+     *                  delegate/listener class references).
+     * @param projectDir the extracted project root (used only to derive the
+     *                  location label for lint items; may be {@code null}).
+     * @param logger    logger for diagnostic output (may be {@code null}).
+     * @return list of lint items; never {@code null}.
+     */
+    public static List<AbstractLintItem> lint(PluginAdapter adapter,
+                                              List<File> bpmnFiles,
+                                              File projectDir,
+                                              Logger logger) {
+        List<AbstractLintItem> items = new ArrayList<>();
+        if (adapter == null) {
+            return items;
+        }
+
+        String pluginLocation = adapter.sourceClass().getName();
+        File locationFile = projectDir != null ? projectDir : new File(".");
+
+        // Step 1: Get the registered @Configuration classes
+        List<Class<?>> registered;
+        try {
+            registered = adapter.getSpringConfigurations();
+        } catch (RuntimeException e) {
+            if (logger != null) {
+                logger.debug("Could not invoke getSpringConfigurations() on plugin '"
+                        + pluginLocation + "': " + e.getMessage());
+            }
+            registered = Collections.emptyList();
+        }
+        if (registered == null) {
+            registered = Collections.emptyList();
+        }
+
+        // Step 2: Collect all BPMN-referenced delegate/listener class names
+        Set<String> referencedBpmnClasses = collectBpmnDelegateReferences(bpmnFiles, logger);
+        if (logger != null) {
+            logger.debug("Spring configuration check: " + referencedBpmnClasses.size()
+                    + " BPMN delegate/listener class reference(s) found.");
+        }
+
+        if (referencedBpmnClasses.isEmpty()) {
+            items.add(PluginLintItem.success(
+                    locationFile,
+                    pluginLocation,
+                    "No BPMN delegate/listener references found; Spring configuration check skipped."
+            ));
+            return items;
+        }
+
+        // Step 3: Build a map of configClassName -> set of @Bean return-type names
+        //         from the REGISTERED configurations only.
+        ClassLoader cl = Thread.currentThread().getContextClassLoader();
+        Map<String, Set<String>> registeredConfigBeans = new LinkedHashMap<>();
+        for (Class<?> configClass : registered) {
+            if (configClass == null) {
+                continue;
+            }
+            Set<String> beanTypes = extractBeanReturnTypes(configClass, logger);
+            registeredConfigBeans.put(configClass.getName(), beanTypes);
+            if (logger != null) {
+                logger.debug("Registered @Configuration '" + configClass.getName()
+                        + "' exposes " + beanTypes.size() + " @Bean type(s).");
+            }
+        }
+
+        // Step 4: For each BPMN-referenced class check whether any registered
+        //         configuration provides a @Bean for it (exact type or supertype).
+        List<String> uncoveredClasses = new ArrayList<>();
+        for (String refClass : referencedBpmnClasses) {
+            boolean covered = false;
+            for (Set<String> beanTypes : registeredConfigBeans.values()) {
+                if (configProvidesClass(beanTypes, refClass, cl)) {
+                    covered = true;
+                    break;
+                }
+            }
+            if (!covered) {
+                uncoveredClasses.add(refClass);
+            }
+        }
+
+        // Step 5: Emit one ERROR per uncovered BPMN-referenced class
+        for (String uncoveredClass : uncoveredClasses) {
+            items.add(new PluginLintItem(
+                    LinterSeverity.ERROR,
+                    LintingType.PLUGIN_DEFINITION_SPRING_CONFIGURATION_MISSING,
+                    locationFile,
+                    uncoveredClass,
+                    "BPMN-referenced class '" + simpleName(uncoveredClass) + "' ("
+                            + uncoveredClass + ") is not provided as a @Bean "
+                            + "in any of the " + registeredConfigBeans.size()
+                            + " @Configuration class(es) registered via getSpringConfigurations() "
+                            + "of plugin '" + adapter.getName() + "'. "
+                            + "Add a @Bean method returning " + simpleName(uncoveredClass)
+                            + " to one of the registered @Configuration classes."
+            ));
+        }
+
+        if (uncoveredClasses.isEmpty()) {
+            items.add(PluginLintItem.success(
+                    locationFile,
+                    pluginLocation,
+                    "getSpringConfigurations() registers " + registered.size()
+                            + " @Configuration class(es); all " + referencedBpmnClasses.size()
+                            + " BPMN delegate/listener reference(s) are covered by a registered @Bean."
+            ));
+        }
+
+        return items;
+    }
+
+    // ==================== BPMN REFERENCE COLLECTION ====================
+
+    private static Set<String> collectBpmnDelegateReferences(List<File> bpmnFiles, Logger logger) {
+        Set<String> refs = new LinkedHashSet<>();
+        if (bpmnFiles == null) {
+            return refs;
+        }
+        for (File bpmnFile : bpmnFiles) {
+            if (bpmnFile == null || !bpmnFile.isFile()) {
+                continue;
+            }
+            try {
+                BpmnModelInstance model = Bpmn.readModelFromFile(bpmnFile);
+                collectFromModel(model, refs);
+            } catch (Exception e) {
+                if (logger != null) {
+                    logger.debug("Could not parse BPMN file for Spring config check: "
+                            + bpmnFile.getAbsolutePath() + " - " + e.getMessage());
+                }
+            }
+        }
+        return refs;
+    }
+
+    private static void collectFromModel(BpmnModelInstance model, Set<String> refs) {
+        for (ServiceTask t : model.getModelElementsByType(ServiceTask.class)) {
+            addIfNotBlank(t.getCamundaClass(), refs);
+            addListenerClasses(t, refs);
+        }
+        for (SendTask t : model.getModelElementsByType(SendTask.class)) {
+            addIfNotBlank(t.getCamundaClass(), refs);
+            addListenerClasses(t, refs);
+        }
+        for (ThrowEvent event : model.getModelElementsByType(ThrowEvent.class)) {
+            addDirectCamundaClass(event, refs);
+            addMessageEventClasses(event.getEventDefinitions(), refs);
+            addListenerClasses(event, refs);
+        }
+        for (BaseElement e : model.getModelElementsByType(BaseElement.class)) {
+            addListenerClasses(e, refs);
+        }
+    }
+
+    private static void addDirectCamundaClass(BaseElement element, Set<String> refs) {
+        String direct = element.getAttributeValueNs(CAMUNDA_NS, "class");
+        addIfNotBlank(direct, refs);
+    }
+
+    private static void addMessageEventClasses(Collection<EventDefinition> defs, Set<String> refs) {
+        if (defs == null) return;
+        for (EventDefinition d : defs) {
+            if (d instanceof MessageEventDefinition med) {
+                addIfNotBlank(med.getCamundaClass(), refs);
+            }
+        }
+    }
+
+    private static void addListenerClasses(BaseElement element, Set<String> refs) {
+        try {
+            for (CamundaExecutionListener l : element.getChildElementsByType(CamundaExecutionListener.class)) {
+                addIfNotBlank(l.getCamundaClass(), refs);
+            }
+        } catch (RuntimeException ignored) {
+            // Element does not support execution listeners – skip silently.
+        }
+        try {
+            for (CamundaTaskListener l : element.getChildElementsByType(CamundaTaskListener.class)) {
+                addIfNotBlank(l.getCamundaClass(), refs);
+            }
+        } catch (RuntimeException ignored) {
+            // Element does not support task listeners – skip silently.
+        }
+    }
+
+    private static void addIfNotBlank(String v, Set<String> target) {
+        if (v != null && !v.isBlank()) {
+            target.add(v.trim());
+        }
+    }
+
+    // ==================== @Bean DISCOVERY ON REGISTERED CONFIGS ====================
+
+    /**
+     * Returns the set of return-type names of all {@code @Bean}-annotated methods
+     * declared directly on {@code configClass}.
+     */
+    private static Set<String> extractBeanReturnTypes(Class<?> configClass, Logger logger) {
+        Set<String> beanReturnTypes = new LinkedHashSet<>();
+        try {
+            for (Method m : configClass.getDeclaredMethods()) {
+                if (hasAnnotationByName(m.getAnnotations())) {
+                    Class<?> rt = m.getReturnType();
+                    if (rt != void.class && rt != Void.class) {
+                        beanReturnTypes.add(rt.getName());
+                    }
+                }
+            }
+        } catch (Throwable t) {
+            if (logger != null) {
+                logger.debug("Could not read @Bean methods of '"
+                        + configClass.getName() + "': " + t.getMessage());
+            }
+        }
+        return beanReturnTypes;
+    }
+
+    private static boolean hasAnnotationByName(Annotation[] annotations) {
+        if (annotations == null) return false;
+        for (Annotation a : annotations) {
+            if (a == null) continue;
+            Class<? extends Annotation> type = a.annotationType();
+            if (type != null && SpringConfigurationLinter.BEAN_ANNOTATION.equals(type.getName())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Returns {@code true} if the set of {@code @Bean} return-type names includes
+     * {@code referencedClass} exactly, or if any listed type is a supertype of
+     * {@code referencedClass} (to handle abstract/interface return types).
+     */
+    private static boolean configProvidesClass(Set<String> beanReturnTypes,
+                                               String referencedClass,
+                                               ClassLoader cl) {
+        if (beanReturnTypes.contains(referencedClass)) {
+            return true;
+        }
+        if (cl == null) {
+            return false;
+        }
+        Class<?> ref;
+        try {
+            ref = Class.forName(referencedClass, false, cl);
+        } catch (ClassNotFoundException | LinkageError e) {
+            return false;
+        }
+        for (String rt : beanReturnTypes) {
+            try {
+                Class<?> returnType = Class.forName(rt, false, cl);
+                if (returnType.isAssignableFrom(ref)) {
+                    return true;
+                }
+            } catch (ClassNotFoundException | LinkageError ignored) {
+                // ignore and continue
+            }
+        }
+        return false;
+    }
+
+    private static String simpleName(String fqn) {
+        int i = fqn.lastIndexOf('.');
+        return (i >= 0) ? fqn.substring(i + 1) : fqn;
+    }
+}

--- a/linter-core/src/test/java/dev/dsf/linter/service/SampleAppConfig.java
+++ b/linter-core/src/test/java/dev/dsf/linter/service/SampleAppConfig.java
@@ -1,0 +1,25 @@
+package dev.dsf.linter.service;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Sample {@code @Configuration} class used by
+ * {@link SpringConfigurationLinterIntegrationTest} to simulate a real
+ * DSF plugin configuration. The {@code @Bean} method return type matches
+ * the {@code camunda:class} reference placed into the test BPMN file,
+ * so the linter can cross-reference them.
+ */
+@Configuration
+public class SampleAppConfig {
+
+    /**
+     * A {@code @Bean} method whose return type is a BPMN-delegate-like class.
+     * The actual behavior is irrelevant for the linter – only the return type
+     * is inspected.
+     */
+    @Bean
+    public SampleDelegate sampleDelegate() {
+        return new SampleDelegate();
+    }
+}

--- a/linter-core/src/test/java/dev/dsf/linter/service/SampleDelegate.java
+++ b/linter-core/src/test/java/dev/dsf/linter/service/SampleDelegate.java
@@ -1,0 +1,8 @@
+package dev.dsf.linter.service;
+
+/**
+ * A stand-in for a BPMN service-task delegate class. Referenced via
+ * {@code camunda:class} in the integration test's BPMN file.
+ */
+public class SampleDelegate {
+}

--- a/linter-core/src/test/java/dev/dsf/linter/service/SpringConfigurationLinterIntegrationTest.java
+++ b/linter-core/src/test/java/dev/dsf/linter/service/SpringConfigurationLinterIntegrationTest.java
@@ -1,0 +1,137 @@
+package dev.dsf.linter.service;
+
+import dev.dsf.linter.logger.Logger;
+import dev.dsf.linter.output.LinterSeverity;
+import dev.dsf.linter.output.LintingType;
+import dev.dsf.linter.output.item.AbstractLintItem;
+import dev.dsf.linter.plugin.PluginDefinitionDiscovery.PluginAdapter;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration-style tests for {@link SpringConfigurationLinter}.
+ *
+ * <p>Verifies the core rule: every class referenced as a Camunda delegate or
+ * listener in a BPMN file must be provided as a {@code @Bean} in at least one
+ * of the {@code @Configuration} classes returned by
+ * {@code ProcessPluginDefinition#getSpringConfigurations()}.</p>
+ */
+class SpringConfigurationLinterIntegrationTest {
+
+    private Path tempProjectRoot;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        tempProjectRoot = Files.createTempDirectory("spring-config-integ-");
+    }
+
+    @AfterEach
+    void tearDown() {
+        deleteRecursively(tempProjectRoot.toFile());
+    }
+
+    @Test
+    void missingRegistration_producesError() throws IOException {
+        // BPMN references SampleDelegate; Object.class has no @Bean for it → ERROR.
+        File bpmn = writeBpmn(tempProjectRoot, SampleDelegate.class.getName());
+
+        PluginAdapter adapter = stubAdapter(List.of(Object.class));
+
+        List<AbstractLintItem> items = SpringConfigurationLinter.lint(
+                adapter, List.of(bpmn), tempProjectRoot.toFile(), silentLogger());
+
+        AbstractLintItem errorItem = items.stream()
+                .filter(i -> i.getSeverity() == LinterSeverity.ERROR)
+                .findFirst()
+                .orElse(null);
+        assertNotNull(errorItem, "Expected an ERROR when the BPMN-referenced class has no @Bean");
+        assertEquals(LintingType.PLUGIN_DEFINITION_SPRING_CONFIGURATION_MISSING, errorItem.getType());
+        assertTrue(errorItem.getDescription().contains(SampleDelegate.class.getSimpleName()),
+                "Error description should mention the uncovered BPMN-referenced class");
+
+        assertFalse(items.stream().anyMatch(i -> i.getSeverity() == LinterSeverity.SUCCESS),
+                "No SUCCESS item expected when at least one reference is uncovered");
+    }
+
+    @Test
+    void registeredConfiguration_producesSuccess() throws IOException {
+        File bpmn = writeBpmn(tempProjectRoot, SampleDelegate.class.getName());
+
+        PluginAdapter adapter = stubAdapter(List.of(SampleAppConfig.class));
+
+        List<AbstractLintItem> items = SpringConfigurationLinter.lint(
+                adapter, List.of(bpmn), tempProjectRoot.toFile(), silentLogger());
+
+        assertFalse(items.stream().anyMatch(i -> i.getSeverity() == LinterSeverity.ERROR),
+                "Expected no ERROR when the required configuration is registered");
+        assertTrue(items.stream().anyMatch(i -> i.getSeverity() == LinterSeverity.SUCCESS),
+                "Expected a SUCCESS item when all references resolve");
+    }
+
+    // ==================== Helpers ====================
+
+    private static PluginAdapter stubAdapter(List<Class<?>> springConfigs) {
+        return new PluginAdapter() {
+            @Override public String getName() { return "sample-plugin"; }
+            @Override public List<String> getProcessModels() { return Collections.emptyList(); }
+            @Override public Map<String, List<String>> getFhirResourcesByProcessId() { return Collections.emptyMap(); }
+            @Override public Class<?> sourceClass() { return SampleAppConfig.class; }
+            @Override public String getResourceVersion() { return "1.0"; }
+            @Override public List<Class<?>> getSpringConfigurations() { return springConfigs; }
+        };
+    }
+
+    private static Logger silentLogger() {
+        return new Logger() {
+            @Override public void info(String message) {}
+            @Override public void warn(String message) {}
+            @Override public void error(String message) {}
+            @Override public void error(String message, Throwable throwable) {}
+            @Override public void debug(String message) {}
+            @Override public boolean verbose() { return false; }
+            @Override public boolean isVerbose() { return false; }
+        };
+    }
+
+    private static File writeBpmn(Path dir, String camundaClass) throws IOException {
+        String bpmn = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                                  xmlns:camunda="http://camunda.org/schema/1.0/bpmn"
+                                  targetNamespace="http://example.org">
+                  <bpmn:process id="testorg_test" isExecutable="true">
+                    <bpmn:serviceTask id="ST" name="select targets" camunda:class="%s"/>
+                  </bpmn:process>
+                </bpmn:definitions>
+                """.formatted(camundaClass);
+        Path p = dir.resolve("sample.bpmn");
+        Files.writeString(p, bpmn, StandardCharsets.UTF_8);
+        return p.toFile();
+    }
+
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    private static void deleteRecursively(File f) {
+        if (f == null || !f.exists()) return;
+        File[] kids = f.listFiles();
+        if (kids != null) {
+            for (File k : kids) deleteRecursively(k);
+        }
+        f.delete();
+    }
+}

--- a/linter-core/src/test/java/dev/dsf/linter/service/SpringConfigurationLinterTest.java
+++ b/linter-core/src/test/java/dev/dsf/linter/service/SpringConfigurationLinterTest.java
@@ -1,0 +1,199 @@
+package dev.dsf.linter.service;
+
+import dev.dsf.linter.logger.Logger;
+import dev.dsf.linter.output.LinterSeverity;
+import dev.dsf.linter.output.LintingType;
+import dev.dsf.linter.output.item.AbstractLintItem;
+import dev.dsf.linter.plugin.PluginDefinitionDiscovery.PluginAdapter;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link SpringConfigurationLinter}.
+ *
+ * <p>These tests exercise the decisions the linter makes from the
+ * {@link PluginAdapter#getSpringConfigurations()} result and BPMN input.
+ * The linter checks whether every BPMN-referenced class is provided as a
+ * {@code @Bean} in one of the registered {@code @Configuration} classes.</p>
+ */
+class SpringConfigurationLinterTest {
+
+    private Path tempProjectRoot;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        tempProjectRoot = Files.createTempDirectory("spring-config-linter-test-");
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        if (tempProjectRoot != null) {
+            deleteRecursively(tempProjectRoot.toFile());
+        }
+    }
+
+    @Test
+    void emptySpringConfigurations_noBpmn_yieldsSuccess() {
+        // Empty registered list + no BPMN references → nothing to check → SUCCESS.
+        PluginAdapter adapter = stubAdapter(Collections.emptyList());
+
+        List<AbstractLintItem> items = SpringConfigurationLinter.lint(
+                adapter, Collections.emptyList(), tempProjectRoot.toFile(), null);
+
+        assertEquals(1, items.size(), "Expected exactly one lint item");
+        assertEquals(LinterSeverity.SUCCESS, items.getFirst().getSeverity());
+    }
+
+    @Test
+    void emptySpringConfigurations_withBpmn_yieldsError() throws IOException {
+        // Empty registered list + BPMN reference → no @Bean can cover it → ERROR.
+        File bpmn = writeBpmn(tempProjectRoot, "com.example.MyDelegate");
+        PluginAdapter adapter = stubAdapter(Collections.emptyList());
+
+        List<AbstractLintItem> items = SpringConfigurationLinter.lint(
+                adapter, List.of(bpmn), tempProjectRoot.toFile(), silentLogger());
+
+        assertTrue(items.stream().anyMatch(i -> i.getSeverity() == LinterSeverity.ERROR),
+                "Expected ERROR when no registered config can cover a BPMN reference");
+    }
+
+    @Test
+    void nonEmptyConfigurations_noBpmn_noProjectScan_yieldsSuccess() {
+        PluginAdapter adapter = stubAdapter(List.of(DummyConfig.class));
+
+        List<AbstractLintItem> items = SpringConfigurationLinter.lint(
+                adapter, Collections.emptyList(), tempProjectRoot.toFile(), null);
+
+        assertEquals(1, items.size());
+        assertEquals(LinterSeverity.SUCCESS, items.getFirst().getSeverity());
+        assertEquals(LintingType.SUCCESS, items.getFirst().getType());
+    }
+
+    @Test
+    void nullProjectDir_nonEmptyConfigurations_yieldsSuccess() {
+        PluginAdapter adapter = stubAdapter(List.of(DummyConfig.class));
+
+        List<AbstractLintItem> items = SpringConfigurationLinter.lint(
+                adapter, Collections.emptyList(), null, null);
+
+        assertEquals(1, items.size());
+        assertEquals(LinterSeverity.SUCCESS, items.getFirst().getSeverity());
+    }
+
+    @Test
+    void bpmnReference_notCoveredByRegisteredBean_yieldsError() throws IOException {
+        // DummyConfig has no @Bean methods at all, so the BPMN-referenced class
+        // cannot be resolved → the linter must report an ERROR.
+        File bpmn = writeBpmn(tempProjectRoot,
+                "dev.dsf.bpe.service.SelectPingTargets");
+
+        PluginAdapter adapter = stubAdapter(List.of(DummyConfig.class));
+
+        List<AbstractLintItem> items = SpringConfigurationLinter.lint(
+                adapter, List.of(bpmn), tempProjectRoot.toFile(), silentLogger());
+
+        assertTrue(items.stream().anyMatch(i -> i.getSeverity() == LinterSeverity.ERROR),
+                "Expected ERROR when a BPMN-referenced class has no matching @Bean");
+        assertFalse(items.stream().anyMatch(i -> i.getSeverity() == LinterSeverity.SUCCESS),
+                "No SUCCESS item expected when at least one reference is uncovered");
+    }
+
+    @Test
+    void bpmnReference_coveredByRegisteredBean_yieldsSuccess() throws IOException {
+        // ConfigWithBean declares a @Bean for the exact BPMN-referenced class → SUCCESS.
+        File bpmn = writeBpmn(tempProjectRoot,
+                ConfigWithBean.BeanClass.class.getName());
+
+        PluginAdapter adapter = stubAdapter(List.of(ConfigWithBean.class));
+
+        List<AbstractLintItem> items = SpringConfigurationLinter.lint(
+                adapter, List.of(bpmn), tempProjectRoot.toFile(), silentLogger());
+
+        assertFalse(items.stream().anyMatch(i -> i.getSeverity() == LinterSeverity.ERROR),
+                "No ERROR expected when the BPMN reference is covered by a registered @Bean");
+        assertTrue(items.stream().anyMatch(i -> i.getSeverity() == LinterSeverity.SUCCESS),
+                "Expected SUCCESS when all BPMN references are covered");
+    }
+
+
+    // ==================== Helpers ====================
+
+    private static PluginAdapter stubAdapter(List<Class<?>> springConfigs) {
+        return new PluginAdapter() {
+            @Override public String getName() { return "test-plugin"; }
+            @Override public List<String> getProcessModels() { return Collections.emptyList(); }
+            @Override public Map<String, List<String>> getFhirResourcesByProcessId() { return Collections.emptyMap(); }
+            @Override public Class<?> sourceClass() { return DummyConfig.class; }
+            @Override public String getResourceVersion() { return "1.0"; }
+            @Override public List<Class<?>> getSpringConfigurations() { return springConfigs; }
+        };
+    }
+
+    private static Logger silentLogger() {
+        return new Logger() {
+            @Override public void info(String message) {}
+            @Override public void warn(String message) {}
+            @Override public void error(String message) {}
+            @Override public void error(String message, Throwable throwable) {}
+            @Override public void debug(String message) {}
+            @Override public boolean verbose() { return false; }
+            @Override public boolean isVerbose() { return false; }
+        };
+    }
+
+    private static File writeBpmn(Path dir, String camundaClass) throws IOException {
+        String bpmn = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                                  xmlns:camunda="http://camunda.org/schema/1.0/bpmn"
+                                  targetNamespace="http://example.org">
+                  <bpmn:process id="testorg_test" isExecutable="true">
+                    <bpmn:serviceTask id="ST" name="select targets" camunda:class="%s"/>
+                  </bpmn:process>
+                </bpmn:definitions>
+                """.formatted(camundaClass);
+        Path p = dir.resolve("sample.bpmn");
+        Files.writeString(p, bpmn, StandardCharsets.UTF_8);
+        return p.toFile();
+    }
+
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    private static void deleteRecursively(File f) {
+        if (f == null || !f.exists()) return;
+        File[] kids = f.listFiles();
+        if (kids != null) {
+            for (File k : kids) deleteRecursively(k);
+        }
+        f.delete();
+    }
+
+    /** Placeholder with no @Bean methods – any BPMN reference will be uncovered. */
+    static final class DummyConfig {
+    }
+
+    /** Config that provides exactly one @Bean for {@link BeanClass}. */
+    static final class ConfigWithBean {
+        static final class BeanClass {
+        }
+
+        @org.springframework.context.annotation.Bean
+        public BeanClass beanClass() {
+            return new BeanClass();
+        }
+    }
+}


### PR DESCRIPTION

### Summary

This pull request introduces validation for BPMN delegate and listener classes against registered Spring configuration beans. It enhances linting functionality to ensure correctness in BPMN plugins.

### Changes

- Added `SpringConfigurationLinter` to validate BPMN delegates and listeners with Spring beans.
- Enhanced `PluginLintingOrchestrator` to include the new linting logic.
- Introduced integration tests to verify the validation process using mock configurations.
- Added unit tests to ensure correctness of the `SpringConfigurationLinter`.
- Added support for retrieving and handling Spring configuration classes in plugin definitions.
- Added a new error type for missing Spring configuration.

### Logic
The `SpringConfigurationLinter` implements the following validation logic:

### 1. Configuration Discovery
* The linter invokes `getSpringConfigurations()` via the `PluginAdapter` to identify all registered `@Configuration` classes.

### 2. BPMN Reference Extraction
* All project BPMN files are scanned for `camunda:class` attributes.
* The scanner extracts class names from **Service Tasks**, **Send Tasks**, **Message Events**, **Execution Listeners**, and **Task Listeners**.

### 3. Bean Analysis
* For each registered configuration, the linter identifies methods annotated with `@Bean`.
* It collects the **return types** of these methods, as these represent the beans available in the Spring context.

### 4. Cross-Referencing & Hierarchy Check
* The linter verifies if each BPMN-referenced class is covered by a registered `@Bean`.

### 5. Output
* **ERROR:** Emitted for any BPMN-referenced class not provided by a registered configuration.
* **SUCCESS:** Emitted if all references are covered or none exist.
